### PR TITLE
fix typo in underscore macro docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ easily.
 
 #### Example:
 
-`@_ data |> reduce(+,_)` expands to `data |> x->reduce(+,_)`
+`@_ data |> reduce(+,_)` expands to `data |> x->reduce(+,x)`
 
 ## TODO
 

--- a/src/underscore.jl
+++ b/src/underscore.jl
@@ -44,7 +44,7 @@ pipe operators.
 
 # Examples
 
-`data |> reduce(+,_)`  expands to  `data |> x->reduce(+,_)`
+`data |> reduce(+,_)`  expands to  `data |> x->reduce(+,x)`
 
 `data |> foo(bar(_))`  expands to  `data |> x->foo(bar(x))`
 


### PR DESCRIPTION
The `_` wasn't replaced in one of the examples