### PR TITLE
remove Callable constraint in mapview()

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -107,9 +107,9 @@ julia> b
   -3
 ```
 """
-mapview(f::Callable, a) = MappedIterator(f, a)
-mapview(f::Callable, a::AbstractArray{T, N}) where {T, N} = MappedArray{promote_op(f, T), N, typeof(f), typeof(a)}(f, a)
-function mapview(f::Callable, d::AbstractDictionary)
+mapview(f, a) = MappedIterator(f, a)
+mapview(f, a::AbstractArray{T, N}) where {T, N} = MappedArray{promote_op(f, T), N, typeof(f), typeof(a)}(f, a)
+function mapview(f, d::AbstractDictionary)
     I = keytype(d)
     T = Core.Compiler.return_type(f, Tuple{eltype(d)})
     


### PR DESCRIPTION
There is no ambiguity in the first mapview() argument anyway.
This makes it possible to use any callable (not covered by `Base.Callable`) as `f` in `mapview` - for example, `@optic(...)` from Accessors.jl.