### PR TITLE
Eliminate `haskey` piracy

### DIFF
--- a/src/SplitApplyCombine.jl
+++ b/src/SplitApplyCombine.jl
@@ -41,9 +41,12 @@ include("combinedims.jl")
 include("invert.jl")
 
 # Silly definitions missing from Base
+# (defining them here is piracy)
 # ===================================
-# this should always work
-Base.haskey(a, i) = i ∈ keys(a) 
+
+if !hasmethod(Base.haskey, (Any, Any))
+    Base.haskey(a, i) = i ∈ keys(a)
+end
 
 if VERSION < v"1.2"
     keytype(a::AbstractArray) = eltype(keys(a))


### PR DESCRIPTION
On nightly, we get this warning:

WARNING: Method definition haskey(Any, Any) in module Base at abstractdict.jl:17 overwritten in module SplitApplyCombine at /home/tim/.julia/packages/SplitApplyCombine/ulZAx/src/SplitApplyCombine.jl:46.
  ** incremental compilation may be fatally broken for this module **

Make the definition conditional on whether it's already present in Base.

This method was added in https://github.com/JuliaLang/julia/pull/42679. Investigated due to this package triggering PkgEval errors in https://github.com/JuliaLang/julia/pull/43759.