### PR TITLE
generalize groupby and mapmany types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,12 +10,14 @@ Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 
 [targets]
-test = ["Test", "StaticArrays"]
+test = ["Test", "StaticArrays", "StructArrays"]
 
 [compat]
 julia = "1"
 Indexing = "1.1"
 Dictionaries = "0.3"
 StaticArrays = "1"
+StructArrays = "0.6.11"

--- a/src/group.jl
+++ b/src/group.jl
@@ -52,8 +52,12 @@ function group(groups, values)
 
     out = Dictionary{I, Vector{T}}()
     @inbounds for (group, value) in zip(groups, values)
-        tmp = get!(() -> T[value], out, group)
-        last(tmp) == value || push!(tmp, value)
+        (hadtoken, token) = gettoken!(out, group)
+        if hadtoken
+            push!(gettokenvalue(out, token), value)
+        else
+            settokenvalue!(out, token, T[value])
+        end
     end
 
     return out

--- a/src/map.jl
+++ b/src/map.jl
@@ -19,12 +19,18 @@ julia> mapmany(x -> 1:x, [1,2,3])
 """
 function mapmany(f::Callable, a)
     T = eltype(promote_op(f, eltype(a)))
-    out = T[]
-    for x ∈ a
+    afirst, state = iterate(a)
+    arest = Iterators.rest(a, state)
+    out = _similar_with_content(f(afirst), T)
+    for x ∈ arest
         append!(out, f(x))
     end
     return out
 end
+
+_similar_with_content(A::AbstractVector, ::Type{T}) where {T} = similar(A, T) .= A
+_similar_with_content(A::AbstractArray, ::Type{T}) where {T} = _similar_with_content(vec(A), T)
+_similar_with_content(A, ::Type{T}) where {T} = append!(T[], A)
 
 mapmany(f::Callable, a, b, c...) = mapmany(x->f(x...), zip(a, b, c...))
 

--- a/test/group.jl
+++ b/test/group.jl
@@ -7,6 +7,8 @@
     @test group((x,y) -> iseven(x+y), (x,y) -> x, 1:10, [1,3,4,2,5,6,4,2,3,9])::Dictionary == dictionary([true => [1,4,5,6,8,9], false => [2,3,7,10]])
 
     @test group(isnothing, [1, 2, 3, nothing, 4, 5, nothing])::Dictionary == dictionary([false => [1, 2, 3, 4, 5], true => [nothing, nothing]])
+    @test group(isodd, [1, 1])::Dictionary == dictionary([true => [1, 1]])
+    @test group(isodd, [1 1; 2 2])::Dictionary == dictionary([true => [1, 1], false => [2, 2]])
 end
 
 @testset "grouponly" begin

--- a/test/group.jl
+++ b/test/group.jl
@@ -9,6 +9,16 @@
     @test group(isnothing, [1, 2, 3, nothing, 4, 5, nothing])::Dictionary == dictionary([false => [1, 2, 3, 4, 5], true => [nothing, nothing]])
     @test group(isodd, [1, 1])::Dictionary == dictionary([true => [1, 1]])
     @test group(isodd, [1 1; 2 2])::Dictionary == dictionary([true => [1, 1], false => [2, 2]])
+
+    G = group(x -> iseven(x.a), StructArray(a=1:10))
+    @test G[true] == [(a=2,), (a=4,), (a=6,), (a=8,), (a=10,)]
+    @test G[true] isa StructArray
+    @test G[true].a == [2, 4, 6, 8, 10]
+
+    G = group(x -> iseven(x.a), StructArray(a=reshape(1:10, 5, 2)))
+    @test G[true] == [(a=2,), (a=4,), (a=6,), (a=8,), (a=10,)]
+    @test G[true] isa StructArray
+    @test G[true].a == [2, 4, 6, 8, 10]
 end
 
 @testset "grouponly" begin
@@ -29,6 +39,12 @@ end
 @testset "groupview" begin
     @test groupview(identity, 11:20)::GroupDictionary == group(identity, 11:20)::Dictionary
     @test groupview(iseven, 11:20)::GroupDictionary == group(iseven, 11:20)::Dictionary
+
+    G = groupview(x -> iseven(x.a), StructArray(a=1:10))
+    @test G[true] == [(a=2,), (a=4,), (a=6,), (a=8,), (a=10,)]
+    @test G[true] isa StructArray
+    @test G[true].a == [2, 4, 6, 8, 10]
+    @test G[true].a isa SubArray
 end
 
 @testset "groupreduce" begin

--- a/test/map.jl
+++ b/test/map.jl
@@ -1,10 +1,26 @@
 @testset "mapmany" begin
-    @test mapmany(i->1:i, 1:3) == [1, 1,2, 1,2,3]
-    @test mapmany((i,j)->1:(i+j), 1:3, 1:3) == [1,2, 1,2,3,4, 1,2,3,4,5,6]
+    @test @inferred(mapmany(i->1:i, 1:3))::Vector{Int} == [1, 1,2, 1,2,3]
+    @test @inferred(mapmany((i,j)->1:(i+j), 1:3, 1:3))::Vector{Int} == [1,2, 1,2,3,4, 1,2,3,4,5,6]
+
+    a = @inferred(mapmany(i -> StructVector(a=1:i), [2, 3]))::StructArray
+    @test a == [(a=1,), (a=2,), (a=1,), (a=2,), (a=3,)]
+    @test a.a == [1, 2, 1, 2, 3]
+
+    cnt = Ref(0)
+    @test mapmany(i -> [cnt[] += 1], 1:3)::Vector{Int} == [1, 2, 3]
+    @test cnt[] == 3
+
+    @test @inferred(mapmany(i -> (j for j in 1:i), (i for i in 1:3))) == [1, 1,2, 1,2,3]
+    @test @inferred(mapmany(i -> 1:i, [1 3; 2 4]))::Vector{Int} == [1, 1,2, 1,2,3, 1,2,3,4]
+    @test @inferred(mapmany(i -> reshape(1:i, 2, :), [2, 4]))::Vector{Int} == [1, 2, 1, 2, 3, 4]
 end
 
 @testset "flatten" begin
-    @test flatten([1:1, 1:2, 1:3]) == [1, 1,2, 1,2,3]
+    @test @inferred(flatten([1:1, 1:2, 1:3])) == [1, 1,2, 1,2,3]
+
+    a = @inferred(flatten([StructVector(a=[1, 2]), StructVector(a=[1, 2, 3])]))::StructArray
+    @test a == [(a=1,), (a=2,), (a=1,), (a=2,), (a=3,)]
+    @test a.a == [1, 2, 1, 2, 3]
 end
 
 @testset "mapview" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SplitApplyCombine
 using Dictionaries
 using StaticArrays
+using StructArrays
 using Test
 
 include("only.jl")


### PR DESCRIPTION
Use `similar()` to create proper array types instead of plain `Vector`s.

Also, a (minor?) fix to group().